### PR TITLE
feat(doh): expose scloud-dns DoH on 8053 and wire edge-gateway proxy

### DIFF
--- a/dns/config/configmap.yaml
+++ b/dns/config/configmap.yaml
@@ -10,7 +10,9 @@
 # Key differences from the upstream example config:
 #   - health_bind changed to 0.0.0.0:8081 (required for k8s probes)
 #   - Only UDP+TCP listeners on 0.0.0.0 (no 10.0.0.1 internal-resolver)
-#   - DoT and DoH disabled (no TLS certs in cluster yet)
+#   - DoT disabled (no TLS certs in cluster yet)
+#   - DoH enabled on 0.0.0.0:8053 (plain HTTP — TLS is terminated at
+#     the edge-gateway, which reverse-proxies /dns-query to us)
 #   - Log to stdout only (no file — logs go to the OTEL collector)
 #   - scloud.internal. zone added as authoritative master
 #   - Recursion allowed for cluster pod CIDRs
@@ -26,9 +28,8 @@ data:
   config.json: |
     {
       "server": {
-        "instance_id": "scloud-dns-k8s",
         "name": "scloud-dns",
-        "version": "0.2.3",
+        "version": "0.3.0",
         "environment": "production",
         "max_concurrent_requests": 5000,
         "graceful_shutdown_timeout_secs": 15,
@@ -40,8 +41,8 @@ data:
         "bind_port": 53
       },
       "workers": {
-        "listener": 4,
         "tcp_acceptor": 1,
+        "doh_acceptor": 1,
         "decoder": 2,
         "query_dispatcher": 1,
         "cache_lookup": 2,
@@ -109,8 +110,13 @@ data:
         }
       ],
       "doh": {
-        "enabled": false,
-        "bind": "0.0.0.0:443"
+        "enabled": true,
+        "bind": "0.0.0.0:8053",
+        "terminate_tls": false,
+        "tls_cert_path": "",
+        "tls_key_path": "",
+        "paths": ["/dns-query"],
+        "allowed_origins": []
       },
       "forwarder": [
         {

--- a/dns/workloads/deployment.yaml
+++ b/dns/workloads/deployment.yaml
@@ -25,7 +25,7 @@ spec:
 
       containers:
         - name: scloud-dns
-          image: ghcr.io/2scloud/scloud-dns:0.2.3-live-stdout
+          image: ghcr.io/2scloud/scloud-dns:0.3.0-doh-stdout
           imagePullPolicy: Always
 
           ports:
@@ -34,6 +34,11 @@ spec:
               protocol: UDP
             - name: dns-tcp
               containerPort: 53
+              protocol: TCP
+            - name: dns-doh
+              # RFC 8484 DoH endpoint. Plain HTTP — TLS is terminated at
+              # the edge-gateway; scloud-dns sits behind it on the pod network.
+              containerPort: 8053
               protocol: TCP
             - name: metrics
               containerPort: 9153
@@ -77,7 +82,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_LOGS_PROTOCOL
               value: "http/protobuf"
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.namespace=scloud-dns,service.version=0.2.3"
+              value: "service.namespace=scloud-dns,service.version=0.3.0"
             - name: OTEL_TRACES_EXPORTER
               value: "none"
             - name: OTEL_METRICS_EXPORTER

--- a/dns/workloads/service.yaml
+++ b/dns/workloads/service.yaml
@@ -18,6 +18,11 @@ spec:
       port: 53
       targetPort: dns-tcp
       protocol: TCP
+    - name: dns-doh
+      # DoH endpoint consumed by the edge-gateway's [doh] proxy route.
+      port: 8053
+      targetPort: dns-doh
+      protocol: TCP
     - name: metrics
       port: 9153
       targetPort: metrics

--- a/gateway/config/configmap.yaml
+++ b/gateway/config/configmap.yaml
@@ -34,6 +34,16 @@ data:
     cache_dir   = "/tmp/wasm-cache"
     max_modules = 64
 
+    [doh]
+    # DoH (RFC 8484) passthrough — the edge gateway receives HTTP DoH
+    # requests on /dns-query and forwards them to scloud-dns's plain-HTTP
+    # DoH endpoint. TLS termination (if any) happens upstream of the
+    # gateway; scloud-dns listens on TCP:8053 without TLS.
+    enabled      = true
+    paths        = ["/dns-query"]
+    upstream_url = "http://scloud-dns.scloud-dns.svc.cluster.local:8053"
+    timeout_ms   = 5000
+
     [[modules]]
     id          = "waf"
     enabled     = true


### PR DESCRIPTION
## Summary

Cluster-side manifest changes to enable DNS-over-HTTPS end-to-end:
- **scloud-dns deployment**: new `dns-doh` container port (TCP 8053); image bumped to `0.3.0-doh-stdout`; OTEL resource version bumped to 0.3.0.
- **scloud-dns service**: new `dns-doh` service port (TCP 8053 → targetPort `dns-doh`).
- **scloud-dns configmap**: `doh.enabled = true` on `0.0.0.0:8053`, `workers.doh_acceptor = 1`, dropped obsolete `workers.listener` field (removed upstream) and `server.instance_id` (removed from struct).
- **edge-gateway configmap**: added `[doh]` block pointing at `http://scloud-dns.scloud-dns.svc.cluster.local:8053`. 

## Test plan
- [X] \`make k8s-reload\` (from the parent repo) rolls out without errors
- [X] Pods come ready: \`kubectl get pods -n scloud-dns\` and \`-n scloud-gateway\`
- [X] DoH reaches the cluster: \`curl -H 'accept: application/dns-message'                                                                                   'https://<gateway-host>/dns-query?dns=AAABAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB' -o /tmp/dns-reply.bin\` returns HTTP 200 with \`application/dns-message\` 

## Known gaps
Response is still an echo of the request bytes until scloud-dns's decoder → resolver → encoder stages emit real DNS answers. This PR ships the transport path only.